### PR TITLE
Add Moonsighting Committee Worldwide (MCW) prayer time configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,10 @@ export const calculationMethods = {
     name: 'Jabatan Kemajuan Islam Malaysia',
     params: { fajr: 20, isha: 18 },
   },
+  MCW: {
+    name: "Moonsighting Committee Worldwide",
+    params: { fajr: 18, isha: 18}
+  }
 } as const;
 
 export type CalculationMethod = keyof typeof calculationMethods;


### PR DESCRIPTION
Added the Moonsighting Committee Worldwide (MCW) prayer time configuration to the existing calculation methods.

Changes Made:
- Added MCW configuration under calculationMethods object.
- Set parameters for Fajr and Isha times to 18.
- 
Purpose: This update introduces the MCW prayer calculation method to enhance flexibility in prayer time configurations, catering to a wider user base who follow this method.